### PR TITLE
Add example of how to link a group map at the schedule_visit page

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ This first snippet of code loads the dependencies for the maps and styles. It sh
 ```
 
 ---
-This next snippet of code will render a map on your webpage with a search bar for 
-s to enter
+This next snippet of code will render a map on your webpage with a search bar for patients to enter
 their location. This can be placed anywhere within the `<body>` tag on your web page.
 
 ```html
@@ -203,6 +202,62 @@ to
         <a class="map-tooltip" onclick="focusMap({{id}})" target="_blank" title="">
           <img src="{{icon_url}}" />&nbsp;
         </a><strong>{{{hospital_name}}}</strong>
+```
+
+### Example: Use a different scheduling page
+
+If you want to direct patients to the Clockwise primary care scheduling page instead of the same-day online scheduling page, replace all instances of `{{{hospital_name_link}}}` and `{{{schedule_button}}}` with links to `https://www.clockwisemd.com/hospitals/{{{hospital_id}}}/appointments/schedule_visit`, optionally using `{{{hospital_name}}}` to show the hospital name as the link text.  The result of doing so for all three Mustache templates would be
+
+```html
+  <script id="map_full_hospital" type="text/template">
+    <div class="map-window-full" id="hospital-window-{{id}}">
+      <h5 class="opensans"><strong>
+        <a href="https://www.clockwisemd.com/hospitals/{{{hospital_id}}}/appointments/schedule_visit">
+          {{{hospital_name}}}
+        </a>
+      </strong></h5>
+      <h5 class="opensans">{{{drive_time}}}</h5>
+      <h5 class="opensans"><strong class="current_wait_placeholder">{{{current_queue_length}}}</strong>&nbsp;in line.</h5>
+      <h5 class="opensans">{{{address_1}}}</h5>
+      <h5 class="opensans">{{{address_2}}}</h5>
+      <h5 class="opensans">{{{city}}}, {{{state}}} {{{zip}}}</h5>
+      <h5 class="opensans">{{{phone_number}}}</h5>
+      <a href="https://www.clockwisemd.com/hospitals/{{{hospital_id}}}/appointments/schedule_visit">
+        <div class='btn btn-primary margin-bottom-10'>Get In Line Now</div>
+      </a>
+    </div>
+  </script>
+  <script id="map_wait_window" type="text/template">
+    <div class="map-window-wait" id="hospital-window-{{id}}">
+      <h5 class="opensans"><strong>
+        <a href="https://www.clockwisemd.com/hospitals/{{{hospital_id}}}/appointments/schedule_visit">
+          {{{hospital_name}}}
+        </a>
+      </strong></h5>
+      <h5 class="opensans">{{{drive_time}}}</h5>
+      <h5 class="opensans"><strong class="current_wait_placeholder">{{{current_queue_length}}}</strong>&nbsp;in line.</h5>
+    </div>
+  </script>
+  <script id="list_full_hospital" type="text/template">
+    <div class="span4 margin-group margin-top text-center" id="list-hospital-{{id}}" style="height:300px">
+      <h4 class="opensans">
+        <a class="map-tooltip" onclick="focusMap({{id}})" target="_blank" title="">
+          <img src="{{icon_url}}" />&nbsp;
+        </a>
+        <strong><a href="https://www.clockwisemd.com/hospitals/{{{hospital_id}}}/appointments/schedule_visit">
+          {{{hospital_name}}}
+        </a></strong>
+      </h4>
+      <h4 class="opensans drive_time_header">{{{drive_time}}}</h4>
+      <h4 class="opensans"><strong class="current_wait_placeholder">{{{current_queue_length}}}</strong>&nbsp;in line.</h4><h4 class="opensans">{{{address_1}}}</h4>
+      <h4 class="opensans">{{{address_2}}}</h4>
+      <h4 class="opensans">{{{city}}}, {{{state}}} {{{zip}}}</h4>
+      <h4 class="opensans">{{{phone_number}}}</h4>
+      <a href="https://www.clockwisemd.com/hospitals/{{{hospital_id}}}/appointments/schedule_visit">
+        <div class='btn btn-primary margin-bottom-10'>Get In Line Now</div>
+      </a>
+    </div>
+  </script>
 ```
 
 ---


### PR DESCRIPTION
Aims to address requests like [this one](https://staging.clockwisemd.com/team/admin/extra_fields/61078) where customers direct their typical patients to the schedule_visit page rather than the new appointments page